### PR TITLE
Fixes a bug that would temporarily disable the escape key when closing a frame using the close button.

### DIFF
--- a/SecureTabs-2.0.lua
+++ b/SecureTabs-2.0.lua
@@ -97,7 +97,13 @@ function Lib:Update(panel, selection)
 				frame:SetFrameLevel(panel:GetFrameLevel() + 20)
 
 				if frame.CloseButton then -- this could cause taint, must solve?
-					frame.CloseButton:SetScript('OnClick',  function() panel:Hide() end)
+					frame.CloseButton:SetScript('OnClick',  function()
+						if frame:GetParent() and frame:GetParent().CloseButton then
+							-- Closes the parent properly
+							UIPanelCloseButton_OnClick(frame:GetParent().CloseButton)
+						end
+						panel:Hide()
+					end)
 				end
 			end
 		end


### PR DESCRIPTION
Hello, a user of my SoulshapeJournal addon reported [a weird bug](https://github.com/christopheml/soulshape-journal/issues/20) where their escape key would not work after closing the frame by clicking on the close button.

I narrowed down the issue and it comes from the custom `CloseButton` `OnClick` handler that does not closes the parent frame properly. Here's a fix I sucessfully tested on the `CollectionsJournal` frame. It also fixes the same issue in PetTracker.

Thank you for writing that lib, it's really handy.