### PR TITLE
OnDeselect doesn't appear to be implemented

### DIFF
--- a/SecureTabs-2.0.lua
+++ b/SecureTabs-2.0.lua
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with SecureTabs. If not, see <http://www.gnu.org/licenses/>.
 --]]
 
-local Lib, old = LibStub:NewLibrary('SecureTabs-2.0', 8)
+local Lib, old = LibStub:NewLibrary('SecureTabs-2.0', 9)
 if not Lib then
 	return
 elseif not old then
@@ -60,6 +60,14 @@ function Lib:Select(tab)
 	if tab.OnSelect then
 		tab:OnSelect()
 	end
+    
+    for _, tabs in pairs(Lib.tabs[tab:GetParent()]) do
+        if tabs ~= tab then
+            if tabs.OnDeselect then
+                tabs:OnDeselect()
+            end
+        end
+    end
 
 	PlaySound(SOUNDKIT.IG_CHARACTER_INFO_TAB)
 	self:Update(tab:GetParent(), tab)

--- a/SecureTabs-2.0.lua
+++ b/SecureTabs-2.0.lua
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with SecureTabs. If not, see <http://www.gnu.org/licenses/>.
 --]]
 
-local Lib, old = LibStub:NewLibrary('SecureTabs-2.0', 7)
+local Lib, old = LibStub:NewLibrary('SecureTabs-2.0', 8)
 if not Lib then
 	return
 elseif not old then
@@ -47,7 +47,7 @@ function Lib:Add(panel, frame, label)
 	PanelTemplates_DeselectTab(tab)
 
 	local cover = self.covers[panel] or CreateFrame('Button', '$parentCoverTab', panel, self.template)
-	cover:SetScript('OnClick', function(tab) self:Uncover(panel) end)
+	cover:HookScript('OnClick', function() self:Uncover(panel, tab) end)
 	PanelTemplates_DeselectTab(cover)
 
 	self.tabs[panel] = secureTabs
@@ -68,7 +68,11 @@ end
 
 --[[ Advanced Methods ]]--
 
-function Lib:Uncover(panel)
+function Lib:Uncover(panel, tab)
+    if tab.OnDeselect then
+        tab:OnDeselect()
+    end
+    
 	PlaySound(SOUNDKIT.IG_CHARACTER_INFO_TAB)
 	self:Update(panel)
 end


### PR DESCRIPTION
Not sure if you were relying on Blizzard code that has been removed, but I can't find any implementation of tab.OnDeselect anywhere in the library or Blizzards code, despite the library instructions indicating it should work.

I've implemented .OnDeselect inside Lib:Uncover, and changed the cover SetScript. The SetScript is changed to HookScript as only the newest tab was being triggered - the SetScript replaced the handler for any tabs created earlier. I've removed the tab parameter into the internal function as it was passing in an irrelevant frame, obscuring the tab button I'm actually interested in.